### PR TITLE
Apply patches to disable BuildKit log clipping by default

### DIFF
--- a/moby-engine/debian/changelog
+++ b/moby-engine/debian/changelog
@@ -1,3 +1,10 @@
+moby-engine (20.10.27-2) UNRELEASED; urgency=medium
+
+  * Backport https://github.com/moby/buildkit/commit/18821ec794e870693763a6fb314064e70efe7969
+  * Apply patch to disable BuildKit log clipping by default
+
+ -- Tianon Gravi <tianon@debian.org>  Mon, 04 Mar 2024 15:42:26 -0800
+
 moby-engine (20.10.27-1) unstable; urgency=medium
 
   * Update to 20.10.27

--- a/moby-engine/debian/patches/buildkit-fixclip.patch
+++ b/moby-engine/debian/patches/buildkit-fixclip.patch
@@ -1,0 +1,28 @@
+Description: fix buildkit clipping configuration
+Applied-Upstream: https://github.com/moby/buildkit/commit/18821ec794e870693763a6fb314064e70efe7969, 21+ (buildkit 0.9+)
+
+diff --git a/vendor/github.com/moby/buildkit/util/progress/logs/logs.go b/vendor/github.com/moby/buildkit/util/progress/logs/logs.go
+index da82c6923eba..73c1a26b50ac 100644
+--- a/vendor/github.com/moby/buildkit/util/progress/logs/logs.go
++++ b/vendor/github.com/moby/buildkit/util/progress/logs/logs.go
+@@ -71,15 +71,16 @@ func (sw *streamWriter) checkLimit(n int) int {
+ 		maxSize = int(math.Ceil(time.Since(sw.created).Seconds())) * defaultMaxLogSpeed
+ 		sw.clipReasonSpeed = true
+ 	}
+-	if maxSize > defaultMaxLogSize {
++	if maxSize == -1 || maxSize > defaultMaxLogSize {
+ 		maxSize = defaultMaxLogSize
+ 		sw.clipReasonSpeed = false
+ 	}
+-	if maxSize < oldSize {
+-		return 0
+-	}
+ 
+ 	if maxSize != -1 {
++		if maxSize < oldSize {
++			return 0
++		}
++
+ 		if sw.size > maxSize {
+ 			return maxSize - oldSize
+ 		}

--- a/moby-engine/debian/patches/buildkit-noclip.patch
+++ b/moby-engine/debian/patches/buildkit-noclip.patch
@@ -1,0 +1,19 @@
+Description: disable buildkit's default log clipping
+Author: Tianon Gravi <tianon@debian.org>
+Forwarded: no (upstream's defaults are intentional, Tianon just disagrees with them)
+
+diff --git a/vendor/github.com/moby/buildkit/util/progress/logs/logs.go b/vendor/github.com/moby/buildkit/util/progress/logs/logs.go
+index bfecdda6b3..079d7e561a 100644
+--- a/vendor/github.com/moby/buildkit/util/progress/logs/logs.go
++++ b/vendor/github.com/moby/buildkit/util/progress/logs/logs.go
+@@ -18,8 +18,8 @@ import (
+ 	"github.com/tonistiigi/units"
+ )
+ 
+-var defaultMaxLogSize = 2 * 1024 * 1024
+-var defaultMaxLogSpeed = 200 * 1024 // per second
++var defaultMaxLogSize = -1
++var defaultMaxLogSpeed = -1
+ 
+ const (
+ 	stdout = 1

--- a/moby-engine/debian/patches/series
+++ b/moby-engine/debian/patches/series
@@ -1,1 +1,3 @@
 containerd-arm64-v8.patch
+buildkit-fixclip.patch
+buildkit-noclip.patch


### PR DESCRIPTION
(backport https://github.com/moby/buildkit/commit/18821ec794e870693763a6fb314064e70efe7969)