### PR TITLE
Disable recursive cloning of submodules given a Git URL

### DIFF
--- a/moby-engine/debian/changelog
+++ b/moby-engine/debian/changelog
@@ -1,3 +1,9 @@
+moby-engine (23.0.11-3) UNRELEASED; urgency=medium
+
+  * Disable recursive cloning of submodules given a Git URL
+
+ -- Tianon Gravi <tianon@debian.org>  Thu, 30 May 2024 15:27:02 -0700
+
 moby-engine (23.0.11-2) unstable; urgency=medium
 
   * Add patch to fix buildkit on mips64le

--- a/moby-engine/debian/patches/git-no-submodules.patch
+++ b/moby-engine/debian/patches/git-no-submodules.patch
@@ -1,0 +1,37 @@
+Description: disable recursive cloning of submodules given a Git URL
+Forwarded: https://github.com/moby/buildkit/issues/4974, https://github.com/moby/moby/pull/3463#issuecomment-31778263
+
+diff --git a/builder/remotecontext/git/gitutils.go b/builder/remotecontext/git/gitutils.go
+index c20f8da75b..09e2b99e76 100644
+--- a/builder/remotecontext/git/gitutils.go
++++ b/builder/remotecontext/git/gitutils.go
+@@ -80,13 +80,6 @@ func (repo gitRepo) clone() (checkoutDir string, err error) {
+ 		return "", err
+ 	}
+ 
+-	cmd := exec.Command("git", "submodule", "update", "--init", "--recursive", "--depth=1")
+-	cmd.Dir = root
+-	output, err := cmd.CombinedOutput()
+-	if err != nil {
+-		return "", errors.Wrapf(err, "error initializing submodules: %s", output)
+-	}
+-
+ 	return checkoutDir, nil
+ }
+ 
+diff --git a/vendor/github.com/moby/buildkit/source/git/gitsource.go b/vendor/github.com/moby/buildkit/source/git/gitsource.go
+index 7b52c11330..9830cd5a63 100644
+--- a/vendor/github.com/moby/buildkit/source/git/gitsource.go
++++ b/vendor/github.com/moby/buildkit/source/git/gitsource.go
+@@ -588,11 +588,6 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out
+ 		}
+ 	}
+ 
+-	_, err = gitWithinDir(ctx, gitDir, checkoutDir, sock, knownHosts, gs.auth, "submodule", "update", "--init", "--recursive", "--depth=1")
+-	if err != nil {
+-		return nil, errors.Wrapf(err, "failed to update submodules for %s", urlutil.RedactCredentials(gs.src.Remote))
+-	}
+-
+ 	if idmap := mount.IdentityMapping(); idmap != nil {
+ 		u := idmap.RootPair()
+ 		err := filepath.Walk(gitDir, func(p string, f os.FileInfo, err error) error {

--- a/moby-engine/debian/patches/series
+++ b/moby-engine/debian/patches/series
@@ -1,3 +1,4 @@
 buildkit-noclip.patch
 containerd-arm64-v8.patch
+git-no-submodules.patch
 mips64le.patch


### PR DESCRIPTION
This causes problems if the submodules are not cloneable and is also a potential vector for abuse in places like DOI where the submodules are *not* supported and not part of the curated review.

- https://github.com/moby/moby/pull/3463#issuecomment-31778263
- https://github.com/moby/buildkit/issues/4974
- https://github.com/tianon/dockerfiles/pull/720