### PR TITLE
Set useful values for PLATFORM in engine/cli

### DIFF
--- a/moby-cli/debian/rules
+++ b/moby-cli/debian/rules
@@ -25,6 +25,10 @@ override_dh_auto_configure:
 	ln -sfT '$(CURDIR)' '$(OUR_GOPATH)/src/github.com/docker/cli'
 
 override_dh_auto_build:
+# embed *somthing* usefully identifying as our "platform"
+	set -eux; \
+	PLATFORM="$$(awk -F ': ' '$$1 ~ /^Vcs-(Browser|Git)$$/ { print $$2; exit }' debian/control)"; \
+	export PLATFORM; \
 	scripts/build/binary
 
 # TODO https://github.com/docker/cli/issues/4212 / https://github.com/docker/cli/pull/4228 😭

--- a/moby-engine/debian/rules
+++ b/moby-engine/debian/rules
@@ -42,6 +42,10 @@ _build-tini: # (docker-init)
 		&& make tini-static
 
 _build-engine:
+# embed *somthing* usefully identifying as our "platform"
+	set -eux; \
+	PLATFORM="$$(awk -F ': ' '$$1 ~ /^Vcs-(Browser|Git)$$/ { print $$2; exit }' debian/control)"; \
+	export PLATFORM; \
 	PRODUCT=docker ./hack/make.sh dynbinary
 
 # basic smoke test to ensure binaries built successfully


### PR DESCRIPTION
This should make my builds have more obvious provenance.

- https://github.com/moby/moby/blob/v23.0.15/hack/make/.go-autogen#L7
- https://github.com/docker/cli/blob/v23.0.15/scripts/build/.variables#L79