### PR TITLE
Add patch for implicit declaration of memcpy in btrfs

### DIFF
--- a/moby-containerd/debian/changelog
+++ b/moby-containerd/debian/changelog
@@ -1,3 +1,9 @@
+moby-containerd (1.6.36-2) UNRELEASED; urgency=medium
+
+  * Add patch for implicit declaration of memcpy in btrfs
+
+ -- Tianon Gravi <tianon@debian.org>  Fri, 14 Mar 2025 17:04:59 -0700
+
 moby-containerd (1.6.36-1) unstable; urgency=medium
 
   * Update to 1.6.36

--- a/moby-containerd/debian/patches/btrfs-implicit-memcpy.patch
+++ b/moby-containerd/debian/patches/btrfs-implicit-memcpy.patch
@@ -1,0 +1,16 @@
+Description: btrfs.c:25:9: error: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
+Author: Tianon Gravi <tianon@debian.org>
+Applied-Upstream: https://github.com/containerd/btrfs/pull/40
+
+diff --git a/vendor/github.com/containerd/btrfs/btrfs.c b/vendor/github.com/containerd/btrfs/btrfs.c
+index f0da012f0..e5fac41d4 100644
+--- a/vendor/github.com/containerd/btrfs/btrfs.c
++++ b/vendor/github.com/containerd/btrfs/btrfs.c
+@@ -19,6 +19,7 @@
+ #include <btrfs/ioctl.h>
+ #include <btrfs/ctree.h>
+ 
++#include <string.h>
+ #include "btrfs.h"
+ 
+ void unpack_root_item(struct gosafe_btrfs_root_item* dst, struct btrfs_root_item* src) {

--- a/moby-containerd/debian/patches/series
+++ b/moby-containerd/debian/patches/series
@@ -1,4 +1,5 @@
 7145-ctr-run-user.patch
 arm64-v8.patch
+btrfs-implicit-memcpy.patch
 remove-opt-plugin.patch
 service-execstart.patch


### PR DESCRIPTION
```
+ bin/containerd
# github.com/containerd/btrfs
btrfs.c: In function ‘unpack_root_item’:
btrfs.c:25:9: error: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
   25 |         memcpy(dst->uuid, src->uuid, BTRFS_UUID_SIZE);
      |         ^~~~~~
btrfs.c:23:1: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
   22 | #include "btrfs.h"
  +++ |+#include <string.h>
   23 | 
btrfs.c:25:9: warning: incompatible implicit declaration of built-in function ‘memcpy’ [-Wbuiltin-declaration-mismatch]
   25 |         memcpy(dst->uuid, src->uuid, BTRFS_UUID_SIZE);
      |         ^~~~~~
btrfs.c:25:9: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
make[2]: *** [Makefile:254: bin/containerd] Error 1
make[2]: Leaving directory '/<<PKGBUILDDIR>>'
make[1]: *** [debian/rules:24: override_dh_auto_build] Error 2
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
make: *** [debian/rules:49: binary] Error 2
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
```